### PR TITLE
Add additional error handling for unsupported HTTP methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,13 @@ const server = http.createServer(async (req, res) => {
     res.end("Invalid URL");
     return;
   }
-  const { pathname } = url; //Destructuring
+  const { pathname } = url; // Destructuring
+
+  if (!["GET", "POST", "PUT", "DELETE"].includes(req.method)) {
+    res.statusCode = 405;
+    res.end("Method Not Allowed");
+    return;
+  }
 
   if (req.method == "GET" && pathname == "/items") {
     await getItems(req, res);


### PR DESCRIPTION
### Description

This pull request adds additional error handling for unsupported HTTP methods in the [`index.js`]file. 
If the HTTP method is not one of GET, POST, PUT, or DELETE, the server will respond with a 405 status code and a "Method Not Allowed" message.

### Changes

- Added check for unsupported HTTP methods.

### Checklist

- [x] Code compiles correctly
- [x] All tests passing
- [x] No linting errors